### PR TITLE
Add support for invoking minion with command line arguments.

### DIFF
--- a/main.js
+++ b/main.js
@@ -156,6 +156,12 @@ app.whenReady().then(() => {
   ipcMain.on("quit", (event) => {
     quit();
   });
+
+  for (var arg of process.argv.slice(1)) {
+    var splitArg = arg.split(' ');
+    console.log("Emitting event '" + splitArg.at(0) + "' with args '" + splitArg.slice(1) + "'");
+    ipcMain.emit(splitArg.at(0), '', ...splitArg.slice(1));
+  }
 });
 
 app.on("quit", () => {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "minimalistic HTML/CSS/JavaScript viewer",
   "main": "main.js",
   "scripts": {
-    "start": "electron-forge start",
+    "start": "electron .",
     "watch": "nodemon --exec electron .",
     "package": "electron-forge package",
     "make": "electron-forge make"


### PR DESCRIPTION
`minion "less test" "shut test" "quit"`

Will now run minion and execute the given commands sequentially. This can be tested in development with a command like:
	'npm run start -- "less test"'