### PR TITLE
Add remaining 'edit' commands to menu

### DIFF
--- a/main.js
+++ b/main.js
@@ -76,6 +76,25 @@ const template = [
       { role: "cut" },
       { role: "copy" },
       { role: "paste" },
+      ...(isMac
+        ? [
+            { role: 'pasteAndMatchStyle' },
+            { role: 'delete' },
+            { role: 'selectAll' },
+            { type: 'separator' },
+            {
+              label: 'Speech',
+              submenu: [
+                { role: 'startSpeaking' },
+                { role: 'stopSpeaking' }
+              ]
+            }
+          ]
+        : [
+            { role: 'delete' },
+            { type: 'separator' },
+            { role: 'selectAll' }
+          ])
     ],
   },
   // view


### PR DESCRIPTION
In this change we add the remaining required edit commands. 
Things like select all and delete.

<img width="361" alt="image" src="https://github.com/3kwa/minion/assets/7734121/43e56fbe-b981-45c2-bc19-333a8464e083">